### PR TITLE
Added CORS Support (External Images)

### DIFF
--- a/seurat.js
+++ b/seurat.js
@@ -64,5 +64,6 @@ Raphael.fn.seurat = function (settings) {
 			if(animator!=null) animator(elm,x,y,step);
 		}
 	}
+	img.crossOrigin = '';
 	img.src = imageSource;
 };


### PR DESCRIPTION
After doing some research I found a really simple way to enable CORS support that will allow users to use external image links.

For reference:
- http://blog.chromium.org/2011/07/using-cross-domain-images-in-webgl-and.html
- http://html5-demos.appspot.com/static/html5-whats-new/template/index.html#14

I'm uncertain if there is a benefit of setting crossOrigin to 'anonymous'. I've decided to leave it blank (as the Chrome team suggests) and it is still working great thus far. I'm assuming it's just a matter of personal preference.

I hope this helps!
