### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 **Website**: http://seuratjs.com
 
 
-##Pointillize and Pixelize all on the Client Side
+## Pointillize and Pixelize all on the Client Side
 
 SeuratJS is a JavaScript library that extends Raphaël and allows for the creation of vivid animations and pixelated artwork using minimal code. It does this by extacting color data from an image of your choice and rebuilding the original with filled graphical primitives in SVG. Seurat makes it extremely easy to alter what primitives are generated (how they look and where they appear) and how they animate.
 
 SeuratJS uses the HTML5 canvas to parse color data and, because of this, the library operates **entirely on the client side**.
 
-##Take it for a Spin
+## Take it for a Spin
 
 Now that you’ve seen how easy it is to use SeuratJS, grab a copy off the source, a copy of RaphaelJS (http://raphaeljs.com/), and create some stunning work of your own.  The examples above are a great starting point and demonstrate using all of the settings.  However, for a more complete reference, the various settings are enumerated below.
 
@@ -27,13 +27,13 @@ Now that you’ve seen how easy it is to use SeuratJS, grab a copy off the sourc
 
 **generator(paper,x,y,color,step,attributes)** - A function to create an element object corresponding to sample (**x**,**y**) from the image. **paper** is the Raphael object we are drawing to. **step** and **attributes** are as described above. **Must return Raphaël element object.**
 
-##Compatibility and Performance
+## Compatibility and Performance
 
 SeuratJS' performance is largely tied to your browser's ability to handle SVG. SeuratJS runs extremely well in IE9 and Chrome. Surprisingly, Firefox can be slightly choppy with a large number of elements.
 
 Long story short, the fewer things moving at one time, the smoother your animation is going to be. If you run into a situation where performance is unsatisfactory, either increase the step size when calling seurat() or increase your animation delays if performance isn't to your liking.
 
-##Authors and Contributors
+## Authors and Contributors
 
 SeuratJS is the work of Greg Smith (@gsmith85). A special thanks to Scott Werner (@swerner) for being a second pair of eyes. 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
